### PR TITLE
Enhance support for custom anchor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dj256/tuiomanager",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "socket.io-client": "4.7.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "scripts": {
     "test": "echo \"No tests yet...\" && exit 0",


### PR DESCRIPTION
* New `anchorX` and `anchorY` properties in all events to get anchor-relative coordinates
* Rename `windowWidth` and `windowHeight` to respectively `anchorWidth` and `anchorHeight`
* Make the `options` parameter optional in `start` method