### PR TITLE
Send same data for delete events

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,15 +20,20 @@ jobs:
       - id: check
         name: Check for version change 📝
         uses: EndBug/version-check@v2
-      - if: steps.check.outputs.changed == 'false'
+      - id: check-force
+        name: Check for force bump 📝
+        run: |
+          echo "force_bump=$(git log -1 HEAD ^origin/master --pretty=%B | grep -Eiom 1 '\[force_bump\]$' |  sed 's/[][]//g')" >> $GITHUB_OUTPUT
+      - if: ${{ steps.check.outputs.changed == 'false' || steps.check-force.outputs.force_bump == 'force_bump' }}
         id: bump
         name: Version bump 👊
         run: |
-          export BUMP_TYPE=$(git log -1 --pretty=%B | grep -Eio '\[(major|minor|patch)\]$' |  sed 's/[][]//g')
+          export BUMP_TYPE=$(git log HEAD ^origin/master --pretty=%B | grep -Eiom 1 '\[(major|minor|patch)\]$' |  sed 's/[][]//g')
           export BUMP_TYPE="${BUMP_TYPE:-patch}"
-          echo version=`npm version $BUMP_TYPE --no-git-tag-version` >> $GITHUB_OUTPUT
-          echo bump_type=$BUMP_TYPE >> $GITHUB_OUTPUT
-      - if: steps.check.outputs.changed == 'false'
+          echo "Bump type: $BUMP_TYPE"
+          echo "version=$(npm version $BUMP_TYPE --no-git-tag-version)" >> $GITHUB_OUTPUT
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+      - if: ${{ steps.check.outputs.changed == 'false' || steps.check-force.outputs.force_bump == 'force_bump' }}
         name: Commit and push 📤
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
@@ -79,7 +84,7 @@ jobs:
       - run: echo "${{ steps.check_dependabot.outputs.dependabot }}"
   comment-pr:
     if: ${{ needs.enable-auto-merge.outputs.dependabot == 'true' && needs.bump-npm-version.outputs.proceed == 'false' }}
-    needs: [enable-auto-merge, bump-npm-version]
+    needs: [ enable-auto-merge, bump-npm-version ]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - id: check
         name: Check for version change 📝
         uses: EndBug/version-check@v2
@@ -24,6 +26,7 @@ jobs:
         name: Check for force bump 📝
         run: |
           echo "force_bump=$(git log -1 HEAD ^origin/master --pretty=%B | grep -Eiom 1 '\[force_bump\]$' |  sed 's/[][]//g')" >> $GITHUB_OUTPUT
+          echo $(git log -1 HEAD ^origin/master --pretty=%B)
       - if: ${{ steps.check.outputs.changed == 'false' || steps.check-force.outputs.force_bump == 'force_bump' }}
         id: bump
         name: Version bump 👊

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dj256/tuiomanager",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "dependencies": {
         "socket.io-client": "4.7.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dj256/tuiomanager",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "dependencies": {
         "socket.io-client": "4.7.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "build": "esbuild src/browser.js --bundle --minify --sourcemap --outfile=dist/tuiomanager.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj256/tuiomanager",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "scripts": {
     "build": "esbuild src/browser.js --bundle --minify --sourcemap --outfile=dist/tuiomanager.js",


### PR DESCRIPTION
Delete events (`tuiotouchup` and `tuiotagup`) only returned the id of the touch or tag. They now return the exact same field as creation and update events